### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "rgbaster",
+  "main": "rgbaster.js",
+  "version": "0.0.0",
+  "homepage": "https://github.com/briangonzalez/rgbaster.js",
+  "authors": [
+    "Brian Gonzalez <me@briangonzalez.org>"
+  ],
+  "description": "A dead simple javascript library for extracting the dominant color from an image.",
+  "keywords": [
+    "rgb",
+    "canvas",
+    "color",
+    "image",
+    "dominant"
+  ],
+  "license": "all rights reserved",
+  "ignore": [
+    "demo"
+  ]
+}


### PR DESCRIPTION
Bower allows easy installation of front-end dependencies. By adding a
`bower.json`, your package is easier to discover and to install, because the
`main` property can provide a hint of where to find the main file of your
project.

You can install RGBaster with `bower install rgbaster`.

Two additional notes:
- You haven't provided any licensing information which means that no-one can use your library without your consent at the moment.
- It would be very helpful if you could tag your library with [semantic versioning](http://semver.org) so people can pin the library to a specific version.
