### PR TITLE
Skip undefined data values

### DIFF
--- a/rgbaster.js
+++ b/rgbaster.js
@@ -71,6 +71,13 @@
                 rgb[2] = data[i+2];
                 rgbString = rgb.join(",");
 
+                // skip undefined data
+                if (rgb.indexOf(undefined) !== -1) {
+                  // Increment!
+                  i += BLOCKSIZE * 4;
+                  continue;
+                }
+
                 // Keep track of counts.
                 if ( rgbString in colorCounts ) {
                   colorCounts[rgbString] = colorCounts[rgbString] + 1;


### PR DESCRIPTION
Currently the class reports `rgb(,,)` for undefined data values.
This patch skips the corresponding values and only counts correct RGB values.