### PR TITLE
Improved Readme / documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,59 @@ RGBaster.colors(img, {
 });
 ```
 
-The `colors` function takes an optional second parameter, which are its options:
+
+### Configuration options
+
+The `colors` function takes an object as optional second parameter, with the following options:
+
+#### `paletteSize`
+Type: `int`
+Default: `10`
+
+Maximum number of palette colors to return. Only the top palette colors will be returned.
+
+#### `exclude`
+Type: `array`
+Default: `[]`
+
+RGB colors to exclude when counting colors.<br>
+For example to exclude white and black use: `[ 'rgb(255,255,255)', 'rgb(0,0,0)' ]`
+
+#### `success`
+Type: `function`
+Default: `undefined`
+
+Function to call after image processing has completed.<br>The function will receive one `payload` argument with the following structure:
+
+```javascript
+{
+    // {string} dominant rgb color
+    dominant:  'rgb(0,0,0)',
+
+    // {string} secondary rgb color
+    secondary: 'rgb(0,0,1)',
+
+    // {array} list of colors in the image (limited by paletteSize)
+    palette:   [ 'rgb(0,0,1)', 'rgb(0,0,2)' ]
+}
+```
+
+### Full example
 
 ```javascript
 RGBaster.colors(img, {
-  paletteSize: 30,
-  exclude: [ 'rgb(255,255,255)' ],  // don't count white
-  success: function(payload){
-    // do something with payload
-  }
+    // return up to 30 top colors from the palette
+    paletteSize: 30,
+
+    // don't count white
+    exclude: [ 'rgb(255,255,255)' ],
+
+    // do something when done
+    success: function(payload){
+        console.log('Dominant color:', payload.dominant);
+        console.log('Secondary color:', payload.secondary);
+        console.log('Palette:', payload.palette);
+    }
 })
 ```
 
@@ -39,7 +83,7 @@ rgbaster.js depends on the following browser functionality:
 
 * [Canvas](http://caniuse.com/#feat=canvas)
 * [CORS](http://caniuse.com/#feat=cors)
-* [Array.prototype.map](http://kangax.github.io/es5-compat-table/#Array.prototype.map)
+* Array.prototype.map ([can i use](http://caniuse.com/#feat=es5), [compatibility table](http://kangax.github.io/es5-compat-table/#Array.prototype.map))
 
 Check the linked resources above to determine current level of browser support.
 


### PR DESCRIPTION
- Configuration options with types/default values and description
- commented example
- Browser support links for `Array.prototype.map`
