### PR TITLE
Fix CORS test - Issue #58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rgbaster",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rgbaster",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A dead simple javascript library for extracting the dominant color(s) from an image.",
   "main": "dist/rgbaster.js",
   "module": "dist/rgbaster.mjs",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,7 @@ export const getImageData = (src: string, scale: number = 1): Promise<Uint8Clamp
 
   // Can't set cross origin to be anonymous for data url's
   // https://github.com/mrdoob/three.js/issues/1305
-  if (src.startsWith('data')) img.crossOrigin = 'Anonymous'
+  if (!src.startsWith('data')) img.crossOrigin = 'Anonymous'
 
   return new Promise((resolve, reject) => {
     img.onload = function () {


### PR DESCRIPTION
CORS test got inverted in v2. The point is to add CORS Anon when the source is not a data string.