### PR TITLE
Add missing types declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "umd:main": "dist/rgbaster.umd.js",
   "unpkg": "dist/rgbaster.umd.js",
   "browser": "dist/rgbaster.umd.js",
+  "types": "dist/index.d.ts",
   "devDependencies": {
     "@jest-runner/electron": "^0.1.0",
     "@types/jest": "^23.3.9",


### PR DESCRIPTION
While the types are created they're not declarated and so they're useless. This add the missing package.json info.